### PR TITLE
[1.18.2] Fix Compressed Dirt uncrafting

### DIFF
--- a/src/main/resources/data/extrautilitiesrebirth/recipes/com_dirt_1rev_rcp.json
+++ b/src/main/resources/data/extrautilitiesrebirth/recipes/com_dirt_1rev_rcp.json
@@ -6,7 +6,7 @@
     }
   ],
   "result": {
-    "item": "minecraft:coarse_dirt",
+    "item": "minecraft:dirt",
     "count": 9
   }
 }


### PR DESCRIPTION
Fix Compressed Dirt not returning minecraft:dirt when uncrafting it