### PR TITLE
[1.18.2] Fix Angel Block

### DIFF
--- a/src/main/java/inzhefop/extrautilitiesrebirth/block/AngelBlockBlock.java
+++ b/src/main/java/inzhefop/extrautilitiesrebirth/block/AngelBlockBlock.java
@@ -44,7 +44,7 @@ public class AngelBlockBlock extends Block {
 	@Override
 	public BlockState getStateForPlacement(BlockPlaceContext context) {
 		return this.defaultBlockState()
-				.setValue(FACING, context.getHorizontalDirection().getOpposite());
+				.setValue(FACING, context.getHorizontalDirection());
 	}
 
 	@SuppressWarnings("deprecation")

--- a/src/main/java/inzhefop/extrautilitiesrebirth/block/AngelBlockBlock.java
+++ b/src/main/java/inzhefop/extrautilitiesrebirth/block/AngelBlockBlock.java
@@ -1,37 +1,39 @@
-
 package inzhefop.extrautilitiesrebirth.block;
 
-import net.minecraft.world.level.storage.loot.LootContext;
-import net.minecraft.world.level.material.Material;
-import net.minecraft.world.level.block.state.properties.DirectionProperty;
-import net.minecraft.world.level.block.state.StateDefinition;
-import net.minecraft.world.level.block.state.BlockState;
-import net.minecraft.world.level.block.state.BlockBehaviour;
-import net.minecraft.world.level.block.SoundType;
-import net.minecraft.world.level.block.Rotation;
-import net.minecraft.world.level.block.Mirror;
-import net.minecraft.world.level.block.HorizontalDirectionalBlock;
-import net.minecraft.world.level.block.Block;
-import net.minecraft.world.level.BlockGetter;
-import net.minecraft.world.item.context.BlockPlaceContext;
-import net.minecraft.world.item.ItemStack;
-import net.minecraft.core.Direction;
 import net.minecraft.core.BlockPos;
-
-import java.util.List;
-import java.util.Collections;
+import net.minecraft.core.Direction;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.context.BlockPlaceContext;
+import net.minecraft.world.level.BlockGetter;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.Block;
+import net.minecraft.world.level.block.HorizontalDirectionalBlock;
+import net.minecraft.world.level.block.Mirror;
+import net.minecraft.world.level.block.Rotation;
+import net.minecraft.world.level.block.SoundType;
+import net.minecraft.world.level.block.state.BlockBehaviour;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.block.state.StateDefinition;
+import net.minecraft.world.level.block.state.properties.DirectionProperty;
+import net.minecraft.world.level.material.FluidState;
+import net.minecraft.world.level.material.Material;
+import org.jetbrains.annotations.NotNull;
 
 public class AngelBlockBlock extends Block {
 	public static final DirectionProperty FACING = HorizontalDirectionalBlock.FACING;
 
 	public AngelBlockBlock() {
-		super(BlockBehaviour.Properties.of(Material.STONE).sound(SoundType.STONE).strength(5f, 8000f));
-		this.registerDefaultState(this.stateDefinition.any().setValue(FACING, Direction.NORTH));
+		super(BlockBehaviour.Properties.of(Material.STONE)
+				.sound(SoundType.STONE)
+				.strength(5f, 8000f));
+		this.registerDefaultState(this.stateDefinition.any()
+				.setValue(FACING, Direction.NORTH));
 	}
 
+	@SuppressWarnings("deprecation")
 	@Override
-	public int getLightBlock(BlockState state, BlockGetter worldIn, BlockPos pos) {
-		return 15;
+	public int getLightBlock(@NotNull BlockState state, BlockGetter world, @NotNull BlockPos pos) {
+		return world.getMaxLightLevel();
 	}
 
 	@Override
@@ -41,22 +43,27 @@ public class AngelBlockBlock extends Block {
 
 	@Override
 	public BlockState getStateForPlacement(BlockPlaceContext context) {
-		return this.defaultBlockState().setValue(FACING, context.getHorizontalDirection().getOpposite());
+		return this.defaultBlockState()
+				.setValue(FACING, context.getHorizontalDirection().getOpposite());
 	}
 
-	public BlockState rotate(BlockState state, Rotation rot) {
+	@SuppressWarnings("deprecation")
+	@Override
+	public @NotNull BlockState rotate(BlockState state, Rotation rot) {
 		return state.setValue(FACING, rot.rotate(state.getValue(FACING)));
 	}
 
-	public BlockState mirror(BlockState state, Mirror mirrorIn) {
+	@SuppressWarnings("deprecation")
+	@Override
+	public @NotNull BlockState mirror(BlockState state, Mirror mirrorIn) {
 		return state.rotate(mirrorIn.getRotation(state.getValue(FACING)));
 	}
 
 	@Override
-	public List<ItemStack> getDrops(BlockState state, LootContext.Builder builder) {
-		List<ItemStack> dropsOriginal = super.getDrops(state, builder);
-		if (!dropsOriginal.isEmpty())
-			return dropsOriginal;
-		return Collections.singletonList(new ItemStack(this, 1));
+	public boolean onDestroyedByPlayer(BlockState state, Level level, BlockPos pos, Player player, boolean willHarvest, FluidState fluid) {
+		if (!player.isCreative()) {
+			player.getInventory().placeItemBackInInventory(this.asItem().getDefaultInstance(), true);
+		}
+		return super.onDestroyedByPlayer(state, level, pos, player, willHarvest, fluid);
 	}
 }

--- a/src/main/java/inzhefop/extrautilitiesrebirth/procedures/AngelBlockprocedureProcedure.java
+++ b/src/main/java/inzhefop/extrautilitiesrebirth/procedures/AngelBlockprocedureProcedure.java
@@ -1,71 +1,64 @@
 package inzhefop.extrautilitiesrebirth.procedures;
 
-import net.minecraftforge.fml.common.Mod;
-import net.minecraftforge.eventbus.api.SubscribeEvent;
-import net.minecraftforge.eventbus.api.Event;
-import net.minecraftforge.event.entity.player.PlayerInteractEvent;
-
-import net.minecraft.world.level.LevelAccessor;
-import net.minecraft.world.level.GameType;
-import net.minecraft.world.level.ClipContext;
-import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.entity.player.Player;
-import net.minecraft.world.entity.LivingEntity;
-import net.minecraft.world.entity.Entity;
-import net.minecraft.server.level.ServerPlayer;
-import net.minecraft.core.BlockPos;
-import net.minecraft.client.Minecraft;
-
-import javax.annotation.Nullable;
-
+import inzhefop.extrautilitiesrebirth.ExtrautilitiesrebirthMod;
+import inzhefop.extrautilitiesrebirth.block.AngelBlockBlock;
 import inzhefop.extrautilitiesrebirth.init.ExtrautilitiesrebirthModBlocks;
+import inzhefop.extrautilitiesrebirth.init.ExtrautilitiesrebirthModItems;
+import net.minecraft.core.BlockPos;
+import net.minecraft.core.Direction;
+import net.minecraft.world.InteractionHand;
+import net.minecraft.world.entity.player.Inventory;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.level.ClipContext;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.phys.Vec3;
+import net.minecraftforge.event.entity.player.PlayerInteractEvent;
+import net.minecraftforge.eventbus.api.SubscribeEvent;
+import net.minecraftforge.fml.common.Mod;
 
-@Mod.EventBusSubscriber
+@Mod.EventBusSubscriber(modid = ExtrautilitiesrebirthMod.MODID, bus = Mod.EventBusSubscriber.Bus.FORGE)
 public class AngelBlockprocedureProcedure {
-	@SubscribeEvent
-	public static void onRightClickItem(PlayerInteractEvent.RightClickItem event) {
-		if (event.getHand() != event.getPlayer().getUsedItemHand())
-			return;
-		execute(event, event.getWorld(), event.getPlayer());
-	}
 
-	public static void execute(LevelAccessor world, Entity entity) {
-		execute(null, world, entity);
-	}
+    @SubscribeEvent
+    public static void onRightClickItem(PlayerInteractEvent.RightClickItem event) {
+        ItemStack stack = event.getItemStack();
+        Item item = stack.getItem();
+        if (item == ExtrautilitiesrebirthModItems.ANGEL_BLOCK.get()) {
+            execute(event.getPlayer(), event.getPlayer().getLevel(), event.getHand());
+        }
+    }
 
-	private static void execute(@Nullable Event event, LevelAccessor world, Entity entity) {
-		if (entity == null)
-			return;
-		if (ExtrautilitiesrebirthModBlocks.ANGEL_BLOCK.get()
-				.asItem() == (entity instanceof LivingEntity _livEnt ? _livEnt.getMainHandItem() : ItemStack.EMPTY).getItem()) {
-			world.setBlock(
-					new BlockPos(
-							entity.level
-									.clip(new ClipContext(entity.getEyePosition(1f), entity.getEyePosition(1f).add(entity.getViewVector(1f).scale(3)),
-											ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, entity))
-									.getBlockPos().getX(),
-							entity.level
-									.clip(new ClipContext(entity.getEyePosition(1f), entity.getEyePosition(1f).add(entity.getViewVector(1f).scale(3)),
-											ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, entity))
-									.getBlockPos().getY(),
-							entity.level
-									.clip(new ClipContext(entity.getEyePosition(1f), entity.getEyePosition(1f).add(entity.getViewVector(1f).scale(3)),
-											ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, entity))
-									.getBlockPos().getZ()),
-					ExtrautilitiesrebirthModBlocks.ANGEL_BLOCK.get().defaultBlockState(), 3);
-			if (!(new Object() {
-				public boolean checkGamemode(Entity _ent) {
-					if (_ent instanceof ServerPlayer _serverPlayer) {
-						return _serverPlayer.gameMode.getGameModeForPlayer() == GameType.CREATIVE;
-					} else if (_ent.level.isClientSide() && _ent instanceof Player _player) {
-						return Minecraft.getInstance().getConnection().getPlayerInfo(_player.getGameProfile().getId()) != null && Minecraft
-								.getInstance().getConnection().getPlayerInfo(_player.getGameProfile().getId()).getGameMode() == GameType.CREATIVE;
-					}
-					return false;
-				}
-			}.checkGamemode(entity))) {
-				((entity instanceof LivingEntity _livEnt ? _livEnt.getMainHandItem() : ItemStack.EMPTY)).shrink(1);
-			}
-		}
-	}
+    private static void execute(Player player, Level level, InteractionHand hand) {
+        if (!level.isClientSide) {
+            Vec3 look = player.getLookAngle();
+            double distance = 3.0;
+            Vec3 offset = look.scale(distance);
+            Vec3 startPos = player.getEyePosition();
+            Vec3 endPos = startPos.add(offset);
+
+            ClipContext context = new ClipContext(startPos, endPos, ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, player);
+            BlockPos blockPos = player.level.clip(context).getBlockPos();
+
+            int y = Math.max(blockPos.getY(), level.getMinBuildHeight());
+            BlockPos pos = new BlockPos(blockPos.getX(), y, blockPos.getZ());
+
+            if (level.isInWorldBounds(pos) && level.getBlockState(pos).getMaterial().isReplaceable()) {
+                Direction direction = player.getDirection();
+                BlockState blockState = ExtrautilitiesrebirthModBlocks.ANGEL_BLOCK.get().defaultBlockState().setValue(AngelBlockBlock.FACING, direction);
+                level.setBlock(pos, blockState, 3);
+
+                if (!player.isCreative()) {
+                    if (hand == InteractionHand.MAIN_HAND) {
+                        player.getInventory().removeFromSelected(false);
+                    } else {
+                        player.getInventory().removeItem(Inventory.SLOT_OFFHAND, 1);
+                    }
+                }
+            }
+        }
+    }
+
 }


### PR DESCRIPTION
* Replaced the complex angel block procedure code with a more straightforward and comprehensible implementation.
* Resolved an issue where angel blocks did not properly rotate when placed mid-air.
* Addressed a problem where angel blocks got consumed when players attempted to place them below bedrock or above build limit while within build limit themselves
* Substituted the deprecated method getDrops(BlockState state, LootContext.Builder builder) with onDestroyedByPlayer(BlockState state, Level level, BlockPos pos, Player player, boolean willHarvest, FluidState fluid) for future proofing
* Angel block now tries to go straight into inventory, then drops int the world if inventory is full